### PR TITLE
[FEAT/#8] Main Navigator를 사용한 SAA 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,4 +81,7 @@ dependencies {
 
     // Coil
     implementation(libs.coil)
+
+    // Navigation
+    implementation(libs.androidx.compose.navigation)
 }

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/home/HomeScreen.kt
@@ -1,0 +1,45 @@
+package com.example.sopkathon_android_team3.presentation.home
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.sopkathon_android_team3.ui.theme.SOPKATHON_ANDROID_TEAM3Theme
+import com.example.sopkathon_android_team3.ui.theme.SopkathonAndroidTeam3Theme
+
+@Composable
+fun HomeRoute(
+    padding: PaddingValues,
+    onNavigateToStorage: () -> Unit
+) {
+    HomeScreen(
+        modifier = Modifier.padding(padding),
+        onNavigateToStorage = onNavigateToStorage
+    )
+}
+
+@Composable
+private fun HomeScreen(
+    onNavigateToStorage: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        modifier = modifier.clickable(onClick = onNavigateToStorage),
+        text = "This is Home Screen",
+        color = SopkathonAndroidTeam3Theme.colors.white
+    )
+}
+
+@Preview
+@Composable
+private fun HomeRoutePreview() {
+    SOPKATHON_ANDROID_TEAM3Theme {
+        HomeRoute(
+            padding = PaddingValues(),
+            onNavigateToStorage = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/home/navigation/HomeNavigation.kt
@@ -1,0 +1,24 @@
+package com.example.sopkathon_android_team3.presentation.home.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.example.sopkathon_android_team3.presentation.home.HomeRoute
+import com.example.sopkathon_android_team3.presentation.model.Route
+
+fun NavController.navigateHome() {
+    navigate(route = Route.Home)
+}
+
+fun NavGraphBuilder.homeNavGraph(
+    padding: PaddingValues,
+    onNavigateToStorage : () -> Unit
+) {
+    composable<Route.Home> {
+        HomeRoute(
+            padding = padding,
+            onNavigateToStorage = onNavigateToStorage
+        )
+    }
+}

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/main/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.example.sopkathon_android_team3.presentation.dummy.DummyScreen
+import androidx.navigation.compose.rememberNavController
 import com.example.sopkathon_android_team3.ui.theme.SOPKATHON_ANDROID_TEAM3Theme
 
 class MainActivity : ComponentActivity() {
@@ -12,8 +12,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
+            val navController = rememberNavController()
+
             SOPKATHON_ANDROID_TEAM3Theme {
-                DummyScreen()
+                MainScreen(navController = navController)
             }
         }
     }

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/main/MainScreen.kt
@@ -1,0 +1,76 @@
+package com.example.sopkathon_android_team3.presentation.main
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import com.example.sopkathon_android_team3.presentation.home.navigation.homeNavGraph
+import com.example.sopkathon_android_team3.presentation.home.navigation.navigateHome
+import com.example.sopkathon_android_team3.presentation.model.Route
+import com.example.sopkathon_android_team3.presentation.storage.navigation.navigateStorage
+import com.example.sopkathon_android_team3.presentation.storage.navigation.storageNavGraph
+import com.example.sopkathon_android_team3.ui.theme.SOPKATHON_ANDROID_TEAM3Theme
+import com.example.sopkathon_android_team3.ui.theme.SopkathonAndroidTeam3Theme
+
+@Composable
+fun MainScreen(
+    navController: NavHostController
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize()
+    ) { innerPadding ->
+        MainNavHost(
+            padding = innerPadding,
+            navController = navController
+        )
+    }
+}
+
+@Composable
+private fun MainNavHost(
+    padding: PaddingValues,
+    navController: NavHostController,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SopkathonAndroidTeam3Theme.colors.black)
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = Route.Home,
+            enterTransition = { EnterTransition.None },
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None }
+        ) {
+            homeNavGraph(
+                padding = padding,
+                onNavigateToStorage = navController::navigateStorage
+            )
+            storageNavGraph(
+                padding = padding,
+                onNavigateToHome = navController::navigateHome
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MainScreenPreview() {
+    SOPKATHON_ANDROID_TEAM3Theme {
+        MainScreen(
+            navController = rememberNavController()
+        )
+    }
+}

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/model/Route.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/model/Route.kt
@@ -1,0 +1,11 @@
+package com.example.sopkathon_android_team3.presentation.model
+
+import kotlinx.serialization.Serializable
+
+sealed interface Route {
+    @Serializable
+    data object Home : Route
+
+    @Serializable
+    data object Storage : Route
+}

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/storage/StorageScreen.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/storage/StorageScreen.kt
@@ -1,0 +1,45 @@
+package com.example.sopkathon_android_team3.presentation.storage
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.sopkathon_android_team3.ui.theme.SOPKATHON_ANDROID_TEAM3Theme
+import com.example.sopkathon_android_team3.ui.theme.SopkathonAndroidTeam3Theme
+
+@Composable
+fun StorageRoute(
+    padding: PaddingValues,
+    onNavigateToHome: () -> Unit
+) {
+    StorageScreen(
+        modifier = Modifier.padding(padding),
+        onNavigateToHome = onNavigateToHome
+    )
+}
+
+@Composable
+private fun StorageScreen(
+    onNavigateToHome: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        modifier = modifier.clickable(onClick = onNavigateToHome),
+        text = "This is Storage Screen",
+        color = SopkathonAndroidTeam3Theme.colors.white
+    )
+}
+
+@Preview
+@Composable
+private fun StorageRoutePreview() {
+    SOPKATHON_ANDROID_TEAM3Theme {
+        StorageRoute(
+            padding = PaddingValues(),
+            onNavigateToHome = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/sopkathon_android_team3/presentation/storage/navigation/StorageNavigation.kt
+++ b/app/src/main/java/com/example/sopkathon_android_team3/presentation/storage/navigation/StorageNavigation.kt
@@ -1,0 +1,24 @@
+package com.example.sopkathon_android_team3.presentation.storage.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.example.sopkathon_android_team3.presentation.model.Route
+import com.example.sopkathon_android_team3.presentation.storage.StorageRoute
+
+fun NavController.navigateStorage() {
+    navigate(route = Route.Storage)
+}
+
+fun NavGraphBuilder.storageNavGraph(
+    padding: PaddingValues,
+    onNavigateToHome: () -> Unit
+) {
+    composable<Route.Storage> {
+        StorageRoute(
+            padding = padding,
+            onNavigateToHome = onNavigateToHome
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ retrofitKotlinSerializationConverter = "1.0.0"
 kotlinxSerializationJson = "1.6.3"
 timber = "5.0.1"
 coil = "2.2.2"
+androidxComposeNavigation = "2.8.2"
+
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,6 +27,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxComposeNavigation" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## Related issue 🛠
- closed #8 

## Work Description 📝
- Compose Navigation 의존성 추가
- SAA 적용
- Home 및 Storage 패키지에 navigation 적용

## Screenshot
https://github.com/user-attachments/assets/4cff1dab-14f5-4ff4-9099-fdeb06b22841

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
현재 텍스트를 누르면 화면이 이동하게끔 설정이 되어 있습니다! 추후 해당 부분은 삭제하시고 Home 및 StorageScreen 화면에서 `HomeScreen` `StorageScreen` 함수 내에 화면 그리시면 됩니다.